### PR TITLE
Replace drawLine with drawFastHLine

### DIFF
--- a/arduboy-pokemon-test/stateNewGame.cpp
+++ b/arduboy-pokemon-test/stateNewGame.cpp
@@ -71,7 +71,7 @@ GameStateID StateNewGame::Run()
 		
 		const uint8_t position = nameForm.getCharIndex();
 		const uint8_t spacing = (position * NameCharacterSpacing);
-		arduboy.drawLine(xOffset + spacing, yOffset + 9, xOffset + spacing + NameUnderlineWidth, yOffset + 9);
+		arduboy.drawFastHLine(xOffset + spacing, yOffset + 9, xOffset + spacing + NameUnderlineWidth);
 		
 		textbox.draw();
 	}

--- a/arduboy-pokemon-test/stateNewGame.cpp
+++ b/arduboy-pokemon-test/stateNewGame.cpp
@@ -71,7 +71,7 @@ GameStateID StateNewGame::Run()
 		
 		const uint8_t position = nameForm.getCharIndex();
 		const uint8_t spacing = (position * NameCharacterSpacing);
-		arduboy.drawFastHLine(xOffset + spacing, yOffset + 9, xOffset + spacing + NameUnderlineWidth);
+		arduboy.drawFastHLine(xOffset + spacing, yOffset + 9, NameUnderlineWidth);
 		
 		textbox.draw();
 	}


### PR DESCRIPTION
Saves 36 bytes

**Before:**
> Sketch uses 13826 bytes (48%) of program storage space. Maximum is 28672 bytes.
> Global variables use 1463 bytes (57%) of dynamic memory, leaving 1097 bytes for local variables. Maximum is 2560 bytes.

**After:**
> Sketch uses 13690 bytes (47%) of program storage space. Maximum is 28672 bytes.
> Global variables use 1463 bytes (57%) of dynamic memory, leaving 1097 bytes for local variables. Maximum is 2560 bytes.
