### PR TITLE
Replace local array with simple print calls

### DIFF
--- a/arduboy-pokemon-test/stateNewGame.cpp
+++ b/arduboy-pokemon-test/stateNewGame.cpp
@@ -87,13 +87,8 @@ GameStateID StateNewGame::Run()
 			} break;
 			case 3:
 			{
-				char str[20] = "hello ";	//hacky, fix
-				for(auto i = 0; i < 8; ++i)
-				{
-					str[i + 6] = context.stats.playerName[i];
-				}
-				
-				textbox.print(str); 
+				textbox.print(F("Hello "));
+				textbox.print(context.stats.playerName);
 			} break;
 			case 4:
 			{


### PR DESCRIPTION
Saves 178 bytes

**Before:**
> Sketch uses 13690 bytes (47%) of program storage space. Maximum is 28672 bytes.
> Global variables use 1463 bytes (57%) of dynamic memory, leaving 1097 bytes for local variables. Maximum is 2560 bytes.

**After:**
> Sketch uses 13512 bytes (47%) of program storage space. Maximum is 28672 bytes.
> Global variables use 1443 bytes (56%) of dynamic memory, leaving 1117 bytes for local variables. Maximum is 2560 bytes.