### PR TITLE
Reorganise textbox

### DIFF
--- a/arduboy-pokemon-test/game.cpp
+++ b/arduboy-pokemon-test/game.cpp
@@ -48,7 +48,7 @@ void Game::Run()
 	
 	arduboy.pollButtons();
 	
-	if(textbox.busy())
+	if(textbox.isActive())
 	{
 		textbox.update(arduboy);
 		textbox.draw(arduboy);

--- a/arduboy-pokemon-test/game.cpp
+++ b/arduboy-pokemon-test/game.cpp
@@ -50,7 +50,7 @@ void Game::Run()
 	
 	if(textbox.busy())
 	{
-		textbox.tick(arduboy);
+		textbox.update(arduboy);
 		textbox.draw(arduboy);
 	}
 	else

--- a/arduboy-pokemon-test/textbox.h
+++ b/arduboy-pokemon-test/textbox.h
@@ -92,7 +92,5 @@ public:
 				this->cursor = 0;
 			}
 		}
-
-		this->draw(arduboy);
 	}
 };

--- a/arduboy-pokemon-test/textbox.h
+++ b/arduboy-pokemon-test/textbox.h
@@ -75,7 +75,7 @@ public:
 		}
 	}
 
-	void tick(Arduboy2 & arduboy)
+	void update(Arduboy2 & arduboy)
 	{
 		if(!this->active)
 			return;

--- a/arduboy-pokemon-test/textbox.h
+++ b/arduboy-pokemon-test/textbox.h
@@ -19,10 +19,9 @@ public:
 	
 	void clear(void)
 	{
-		for(uint8_t i = 0; i < CharMax; ++i)
-			text[i] = ' ';
-		text[0] = '\0';
 		this->cursor = 0;
+		for(uint8_t i = 0; i < CharMax; ++i)
+			text[i] = '\0';
 	}
 	
 	size_t write(uint8_t letter) override

--- a/arduboy-pokemon-test/textbox.h
+++ b/arduboy-pokemon-test/textbox.h
@@ -77,9 +77,6 @@ public:
 
 	void update(Arduboy2 & arduboy)
 	{
-		if(!this->active)
-			return;
-
 		if(this->reveal < this->cursor)
 		{
 			this->reveal++;

--- a/arduboy-pokemon-test/textbox.h
+++ b/arduboy-pokemon-test/textbox.h
@@ -12,7 +12,7 @@ private:
 	uint8_t cursor = 0;
 	uint8_t reveal = 0;
 public:
-	bool busy() const
+	bool isActive() const
 	{
 		return active;
 	}


### PR DESCRIPTION
Several stylistic and behavioural changes that save 14 bytes.

**Before:**
> Sketch uses 13512 bytes (47%) of program storage space. Maximum is 28672 bytes.
> Global variables use 1441 bytes (56%) of dynamic memory, leaving 1119 bytes for local variables. Maximum is 2560 bytes.

**After:**
> Sketch uses 13498 bytes (47%) of program storage space. Maximum is 28672 bytes.
> Global variables use 1441 bytes (56%) of dynamic memory, leaving 1119 bytes for local variables. Maximum is 2560 bytes.
