### PR TITLE
Fix reorganise textbox

### DIFF
--- a/arduboy-pokemon-test/textbox.h
+++ b/arduboy-pokemon-test/textbox.h
@@ -31,7 +31,7 @@ public:
 		
 		if(letter == '\n')
 		{
-			this->cursor  = (((this->cursor / RowLength) + 1) * RowLength) - 1;
+			this->cursor  = (((this->cursor / RowLength) + 1) * RowLength);
 		}
 		else
 		{

--- a/arduboy-pokemon-test/textbox.h
+++ b/arduboy-pokemon-test/textbox.h
@@ -76,7 +76,7 @@ public:
 
 			for(uint8_t x = 0; x < RowLength; ++x)
 			{
-				if(text[index] == '\0')
+				if((index > reveal) || (text[index] == '\0'))
 					return;
 
 				arduboy.print(text[index]);

--- a/arduboy-pokemon-test/textbox.h
+++ b/arduboy-pokemon-test/textbox.h
@@ -3,7 +3,7 @@
 class Textbox : public Print
 {
 private:
-	constexpr static const uint8_t RowLength = 21;
+	constexpr static const uint8_t RowLength = 20;
 	constexpr static const uint8_t RowCount  = 2;
 	constexpr static const uint8_t CharMax = RowLength * RowCount;
 	

--- a/arduboy-pokemon-test/textbox.h
+++ b/arduboy-pokemon-test/textbox.h
@@ -76,7 +76,7 @@ public:
 
 			for(uint8_t x = 0; x < RowLength; ++x)
 			{
-				if((index > reveal) || (text[index] == '\0'))
+				if(index > reveal)
 					return;
 
 				arduboy.print(text[index]);


### PR DESCRIPTION
Behavioural tweaks, restoring char-by-char typewriter functionality and correct linebreaking. The linebreaking thing was actually an error originally on my part, but I won't admit it because i'm stubborn.

Before:

    Sketch uses 13482 bytes (47%) of program storage space. Maximum is 28672 bytes.
    Global variables use 1441 bytes (56%) of dynamic memory, leaving 1119 bytes for local variables. Maximum is 2560 bytes.

After:

    Sketch uses 13480 bytes (47%) of program storage space. Maximum is 28672 bytes.
Global variables use 1439 bytes (56%) of dynamic memory, leaving 1121 bytes for local variables. Maximum is 2560 bytes.

